### PR TITLE
Refactor: 공통 Sidebar 컴포넌트 리팩토링

### DIFF
--- a/src/app/assignment/(components)/Sidebar.example.tsx
+++ b/src/app/assignment/(components)/Sidebar.example.tsx
@@ -1,0 +1,25 @@
+import Sidebar, { Content } from "@/components/Sidebar";
+import React from "react";
+
+// Sidebar 컴포넌트에 전달되어야 하는 데이터 예시입니다.
+const assignmentDummy = [
+  { id: "1", title: "LisTile 커스텀 위젯 만들기", order: 1 },
+  { id: "2", title: "HTTP 리퀘스트 만들기", order: 2 },
+  { id: "3", title: "LisTile 커스텀 위젯 만들기", order: 3 },
+];
+
+// 상위 컴포넌트에서 전달이 필요할 것으로 예상되는 props를 예시로 설정하였으며, 상황에 맞게 수정하신 후 사용해주세요!
+interface AssignmentSidebarProps {
+  course: Content[];
+}
+
+const AssignmentSidebar = () => {
+  return (
+    <aside>
+      <Sidebar header="전체 과제" contents={assignmentDummy} />
+      {/* 이 곳에 button 등 필요한 요소를 넣어서 사용하시면 됩니다. */}
+    </aside>
+  );
+};
+
+export default AssignmentSidebar;

--- a/src/app/classroom/(components)/Course.example.tsx
+++ b/src/app/classroom/(components)/Course.example.tsx
@@ -19,7 +19,7 @@ interface ClassRoomCourse {
   checked: boolean;
 }
 
-// TODO: 추후 Props로 전달받아야 할 데이터 예시
+// Sidebar 컴포넌트에 전달되어야 하는 데이터의 예시이며, 추후 Props로 전달받아서 사용해주세요!
 const courseDummy: ClassRoomCourse = {
   id: "1",
   title: "[DAY1] IT 기본",
@@ -40,8 +40,8 @@ interface ClassRoomCourseProps {
 }
 
 const ClassroomCourse = () => {
-  const [isEdit, setIsEdit] = useState(false); // TODO: 상위 컴포넌트에서 props로 전달받아야 함
-  const [course, setCourse] = useState(courseDummy); // TODO: 데이터 상위 컴포넌트에서 props로 전달받아야 함
+  const [isEdit, setIsEdit] = useState(false); // TODO: 상위 컴포넌트에서 props로 전달받아야 합니다.
+  const [course, setCourse] = useState(courseDummy); // TODO: 데이터는 상위 컴포넌트에서 props로 전달받아야 합니다.
   const [isAllLecturesChecked, setIsAllLecturesChecked] = useState(false);
 
   const checkIsAllLecturesChecked = (lectures: ClassRoomLecture[]) => {
@@ -95,9 +95,7 @@ const ClassroomCourse = () => {
       isCourseChecked={isAllLecturesChecked}
       lectureCheckHandler={lectureCheckHandler}
       courseCheckHandler={courseCheckHandler}
-    >
-      <button onClick={() => setIsEdit(!isEdit)}>강의 수정</button>
-    </Sidebar>
+    />
   );
 };
 

--- a/src/app/classroom/(components)/Course.example.tsx
+++ b/src/app/classroom/(components)/Course.example.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import React, { useEffect, useState } from "react";
+import Sidebar from "@/components/Sidebar";
+import { Course, Lecture } from "@/types/firebase.types";
+
+interface ClassRoomLecture {
+  id: Lecture["id"];
+  title: Lecture["title"];
+  order: number; // Lecture["order"]
+  checked: boolean;
+}
+
+interface ClassRoomCourse {
+  id: Course["id"];
+  title: Course["title"];
+  order: number; // Course["order"]
+  lectures: ClassRoomLecture[];
+  checked: boolean;
+}
+
+// TODO: 추후 Props로 전달받아야 할 데이터 예시
+const courseDummy: ClassRoomCourse = {
+  id: "1",
+  title: "[DAY1] IT 기본",
+  order: 1,
+  lectures: [
+    { id: "0", title: "ListTile 커스텀 위젯 만들기", order: 1, checked: false },
+    { id: "1", title: "HTTP 리퀘스트 보내기", order: 2, checked: true },
+    { id: "2", title: "ListTile 커스텀 위젯 만들기", order: 3, checked: false },
+  ],
+  checked: false,
+};
+
+// TODO: 상위 컴포넌트에서 전달이 필요할 것으로 예상되는 props를 정리해두었으며, 상황에 맞게 수정하신 후 사용해주세요!
+interface ClassRoomCourseProps {
+  isEdit: boolean;
+  setIsEdit: React.Dispatch<React.SetStateAction<boolean>>;
+  course: ClassRoomCourse;
+}
+
+const ClassroomCourse = () => {
+  const [isEdit, setIsEdit] = useState(false); // TODO: 상위 컴포넌트에서 props로 전달받아야 함
+  const [course, setCourse] = useState(courseDummy); // TODO: 데이터 상위 컴포넌트에서 props로 전달받아야 함
+  const [isAllLecturesChecked, setIsAllLecturesChecked] = useState(false);
+
+  const checkIsAllLecturesChecked = (lectures: ClassRoomLecture[]) => {
+    return lectures.every(
+      (courseItem: ClassRoomLecture) => courseItem.checked === true,
+    );
+  };
+
+  const lectureCheckHandler = (id: string) => {
+    const lectureIdx = course.lectures.findIndex(lecture => lecture.id === id);
+    const prevLectureItem = course.lectures[lectureIdx];
+    const newLectureItem = {
+      ...prevLectureItem,
+      checked: !prevLectureItem.checked,
+    };
+    const newCourse = {
+      ...course,
+      lectures: [
+        ...course.lectures.filter(lecture => lecture.id !== id),
+        newLectureItem,
+      ].sort((a, b) => a.order - b.order),
+    };
+
+    setCourse(newCourse);
+  };
+
+  const courseCheckHandler = () => {
+    setIsAllLecturesChecked(!isAllLecturesChecked);
+
+    const newCourse = {
+      ...course,
+      lectures: course.lectures.map(lecture => ({
+        ...lecture,
+        checked: !isAllLecturesChecked,
+      })),
+    };
+
+    setCourse(newCourse);
+  };
+
+  useEffect(() => {
+    setIsAllLecturesChecked(checkIsAllLecturesChecked(course.lectures));
+  }, [course.lectures]);
+
+  return (
+    <Sidebar
+      courseId={course.id}
+      header={course.title}
+      contents={course.lectures}
+      isEdit={isEdit}
+      isCourseChecked={isAllLecturesChecked}
+      lectureCheckHandler={lectureCheckHandler}
+      courseCheckHandler={courseCheckHandler}
+    >
+      <button onClick={() => setIsEdit(!isEdit)}>강의 수정</button>
+    </Sidebar>
+  );
+};
+
+export default ClassroomCourse;

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,33 +1,37 @@
-import { Lecture } from "@/types/firebase.types";
-import React from "react";
+"use client";
 
-type Content = Pick<Lecture, "id" | "title">;
+import { Lecture } from "@/types/firebase.types";
+import React, { useState } from "react";
+
+export interface Content {
+  id: Lecture["id"];
+  title: Lecture["title"];
+  order: number; // Lecture["order"]
+  checked?: boolean;
+}
 
 interface Props {
   courseId?: string;
   header: string;
   contents: Content[];
-  isOpen: boolean;
   isEdit?: boolean;
   isCourseChecked?: boolean;
-  setIsOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  lectureCheckHandler?: (id: string) => void;
   courseCheckHandler?: () => void;
-  children?: React.ReactNode;
 }
 
 const Sidebar = ({
   header,
   contents,
   courseId,
-  isOpen,
   isEdit,
   isCourseChecked,
-  setIsOpen,
+  lectureCheckHandler,
   courseCheckHandler,
-  children,
 }: Props) => {
+  const [isOpen, setIsOpen] = useState(false);
   return (
-    <aside className="w-[245px]">
+    <div className="w-[245px]">
       <div
         className="flex items-center py-[13px] rounded-[10px] text-grayscale-80 bg-primary-5 cursor-pointer"
         onClick={() => setIsOpen(!isOpen)}
@@ -36,8 +40,8 @@ const Sidebar = ({
           {isEdit ? (
             <input
               type="checkbox"
-              onClick={(e: React.MouseEvent<HTMLInputElement>) => {
-                e.stopPropagation();
+              onClick={(e: React.MouseEvent) => e.stopPropagation()}
+              onChange={() => {
                 if (courseCheckHandler !== undefined) courseCheckHandler();
               }}
               value={courseId}
@@ -61,8 +65,11 @@ const Sidebar = ({
                   <input
                     type="checkbox"
                     value={content.id}
-                    checked={isCourseChecked}
-                    disabled
+                    onChange={() => {
+                      if (lectureCheckHandler !== undefined)
+                        lectureCheckHandler(content.id);
+                    }}
+                    checked={content.checked}
                   />
                 )}
               </div>
@@ -71,8 +78,7 @@ const Sidebar = ({
           ))}
         </ul>
       )}
-      {children}
-    </aside>
+    </div>
   );
 };
 


### PR DESCRIPTION
## 개요 :mag:

Sidebar 컴포넌트를 리팩토링하였습니다.

## 작업사항 :memo:

- Classroom Sidebar figma 디자인 변경 사항을 반영하기 위해 children props를 삭제 (기존 하나의 코스에 해당하는 강의들만 보이는 형태 -> 전체 코스에 해당하는 강의가 보이는 형태로 변경)
- Classroom Sidebar 수정모드에서 모든 course title과 lecture title의 checkbox checked 상태가 개별적으로 관리될 수 있도록 Sidebar 컴포넌트의 props 및 코드를 수정
- close #41 

## 테스트 방법(optional)

- Course.example.tsx 파일을 생성하여 Classroom 페이지 적용 예시 코드 작성
  - 1개의 Coure와 포함된 lecture 들에 대한 dummy 데이터를 생성하여 Classroom 페이지에서 Sidebar 컴포넌트의 예시 코드 작성
  - Coure title의 checkbox 클릭 시 해당 coure에 포함된 모든 lecture title의 checked 상태를 true/false로 변경하는 예시 함수 작성
  - 각 lecture title의 checkbox 클릭 시 선택된 lecture title의 checked 상태를 true/false로 변경하는 예시 함수 작성
  - 모든 lecture title의 checked 상태가 ture일 경우 course title의 checked 상태도 ture로, 적어도 하나 이상의 lecture title checked 상태가 false일 경우 course title의 checked 상태도 false로 변경하는 예시 함수 작성
- Sidebar.example.tsx 파일을 생성하여 Assignment 페이지 적용 예시 코드 작성
  - 과제 목록에 대한 dummy 데이터를 생성하여 Assignment 페이지에서 Sidebar 컴포넌트의 예시 코드를 작성