### PR TITLE
Fix: upload

### DIFF
--- a/src/components/upload/FileItem.tsx
+++ b/src/components/upload/FileItem.tsx
@@ -1,11 +1,10 @@
 import React from "react";
-import { AttachmentFile } from "@/types/firebase.types";
 import Image from "next/image";
 import clip from "/public/images/clip.svg";
 
 interface props {
   name: string;
-  setFiles: React.Dispatch<React.SetStateAction<AttachmentFile[]>>;
+  setFiles: React.Dispatch<React.SetStateAction<File[]>>;
 }
 
 export default function FileItem({ name, setFiles }: props) {
@@ -15,14 +14,14 @@ export default function FileItem({ name, setFiles }: props) {
 
   return (
     <li className="w-[690px] h-[50px] flex justify-between items-center text-primary-80">
-      <p className="text-[16px] flex items-center font-bold">
+      <p className="text-[16px] flex items-center font-bold truncate">
         <Image src={clip} alt="" className="mr-[12px]" />
         {name}
       </p>
       <button
         type="button"
         onClick={onClickHandler}
-        className="text-grayscale-100 text-[12px]"
+        className="text-grayscale-100 text-[12px] w-[30px] ml-[40px]"
       >
         삭제
       </button>

--- a/src/components/upload/Upload.tsx
+++ b/src/components/upload/Upload.tsx
@@ -187,7 +187,7 @@ export default function Upload({ role = "lecture", files, setFiles }: props) {
       <label
         htmlFor="fileUpload"
         ref={dragRef}
-        className={`${boxHeight[files.length]} border-[3px] ${
+        className={`${boxHeight[files.length]} border-[2px] ${
           isDragging
             ? "border-primary-80 border-solid"
             : "border-grayscale-20 border-dashed"
@@ -196,7 +196,7 @@ export default function Upload({ role = "lecture", files, setFiles }: props) {
         <p className="text-grayscale-30">파일을 여기로 드래그 해주세요</p>
         <button
           onClick={() => dragRef.current?.click()}
-          className="w-[200px] h-[38px] bg-primary-80 rounded-lg text-white"
+          className="w-[200px] h-[38px] rounded-lg bg-grayscale-5 text-grayscale-50 hover:bg-primary-80 hover:text-white"
         >
           컴퓨터에서 파일 선택
         </button>

--- a/src/components/upload/Upload.tsx
+++ b/src/components/upload/Upload.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { AttachmentFile } from "@/types/firebase.types";
 import React, {
   ChangeEvent,
   useCallback,
@@ -13,8 +12,8 @@ import { v4 as uuid } from "uuid";
 
 interface props {
   role: "lecture" | "assignment";
-  files: AttachmentFile[];
-  setFiles: React.Dispatch<React.SetStateAction<AttachmentFile[]>>;
+  files: File[];
+  setFiles: React.Dispatch<React.SetStateAction<File[]>>;
 }
 
 let allowedFileExtensions: string[] = [];
@@ -97,12 +96,11 @@ export default function Upload({ role = "lecture", files, setFiles }: props) {
       if (fileList !== null && checkNumOfFiles(fileList)) {
         if (role === "lecture" && fileList.length > 1) return;
         for (let i = 0; i < fileList.length; i++) {
-          const file = {
-            name: fileList[i].name,
-            url: URL.createObjectURL(fileList[i]),
-          };
-          if (isValidExtension(file.name) && isExistFile(file.name)) {
-            setFiles(current => [...current, file]);
+          if (
+            isValidExtension(fileList[i].name) &&
+            isExistFile(fileList[i].name)
+          ) {
+            setFiles(prev => [...prev, fileList[i]]);
           }
         }
       }

--- a/src/components/upload/Upload.tsx
+++ b/src/components/upload/Upload.tsx
@@ -16,8 +16,6 @@ interface props {
   setFiles: React.Dispatch<React.SetStateAction<File[]>>;
 }
 
-let allowedFileExtensions: string[] = [];
-
 const boxHeight = [
   "h-[300px]",
   "h-[240px]",
@@ -27,23 +25,33 @@ const boxHeight = [
   "hidden",
 ];
 
+const infoByRole = {
+  lecture: {
+    extensions: ["mp4", "wav", "avi"],
+    fileLimit: 1,
+    errorMsg:
+      "이미 사용 중인 파일이 있습니다. 기존의 파일을 삭제하고 진행해주세요.",
+  },
+  assignment: {
+    extensions: ["pdf", "doc", "docx", "hwp", "hwpx"],
+    fileLimit: 5,
+    errorMsg: "파일은 최대 5개까지 업로드가 가능합니다.",
+  },
+};
+
 export default function Upload({ role = "lecture", files, setFiles }: props) {
   const [isDragging, setIsDragging] = useState<boolean>(false);
   const [error, setError] = useState<string>("");
   const dragRef = useRef<HTMLLabelElement | null>(null);
 
-  if (role === "lecture") {
-    allowedFileExtensions = ["mp4", "wav", "avi"];
-  } else if (role === "assignment") {
-    allowedFileExtensions = ["pdf", "doc", "docx", "hwp", "hwpx"];
-  }
-
   const isValidExtension = useCallback((name: string) => {
     const lastIndex = name.lastIndexOf(".");
     const extension = name.substring(lastIndex + 1).toLowerCase();
-    if (!allowedFileExtensions.includes(extension) || extension === "") {
+    if (!infoByRole[role].extensions.includes(extension) || extension === "") {
       setError(
-        `파일 형식이 올바르지 않습니다. (${allowedFileExtensions.join(", ")})`,
+        `파일 형식이 올바르지 않습니다. (${infoByRole[role].extensions.join(
+          ", ",
+        )})`,
       );
       return false;
     }
@@ -52,27 +60,13 @@ export default function Upload({ role = "lecture", files, setFiles }: props) {
 
   const checkNumOfFiles = useCallback(
     (fileList: FileList): boolean => {
-      let limit = 0;
-      let errorMsg = "";
-
-      if (role === "assignment") {
-        errorMsg = "파일은 최대 5개까지 업로드가 가능합니다.";
-        limit = 5;
-      } else if (role === "lecture") {
-        errorMsg =
-          "이미 사용 중인 파일이 있습니다. 기존의 파일을 삭제하고 진행해주세요.";
-        limit = 1;
-      }
-
-      if (fileList.length > limit) {
-        setError(errorMsg);
+      if (
+        fileList.length > infoByRole[role].fileLimit ||
+        files.length === infoByRole[role].fileLimit
+      ) {
+        setError(infoByRole[role].errorMsg);
         return false;
       }
-      if (files.length === limit) {
-        setError(errorMsg);
-        return false;
-      }
-
       return true;
     },
     [files.length, role],

--- a/src/components/upload/Upload.tsx
+++ b/src/components/upload/Upload.tsx
@@ -62,7 +62,8 @@ export default function Upload({ role = "lecture", files, setFiles }: props) {
     (fileList: FileList): boolean => {
       if (
         fileList.length > infoByRole[role].fileLimit ||
-        files.length === infoByRole[role].fileLimit
+        files.length === infoByRole[role].fileLimit ||
+        fileList.length + files.length > infoByRole[role].fileLimit
       ) {
         setError(infoByRole[role].errorMsg);
         return false;


### PR DESCRIPTION
## 개요 :mag:

파일 업로드 시, URL.createObjectURL() 메서드를 통해서 URL로 변환해주는 작업을 진행하였는데,
firebase storage에 저장하는 데에 있어 파일 형식이 달라 올리지 못하는 문제가 발생하였습니다.

## 작업사항 :memo:

이전 PR시 코멘트 남겨주셨던 부분 반영하였고, 디자인도 수정하였습니다.
업로드 하는 파일의 타입을 AttatchmentFile[] 타입에서 File[]타입으로 변경하였습니다.
이후 필요한 URL같은 경우는 firebase storage의 uploadBytes() 메서드 등을 통해서
storage에 저장 후 반환되는 URL을 사용하시면 될 것 같습니다.
