### PR TITLE
Feat: 리스트dnd wrapper 개발, 사용예제코드작성

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "postcss": "8.4.26",
     "react": "18.2.0",
     "react-dnd": "^16.0.1",
+    "react-dnd-html5-backend": "^16.0.1",
     "react-dom": "18.2.0",
     "react-hook-form": "^7.45.2",
     "react-markdown": "^8.0.7",

--- a/src/components/DnDWrapper.tsx
+++ b/src/components/DnDWrapper.tsx
@@ -1,0 +1,86 @@
+"use client";
+import React, { useState } from "react";
+import { DndProvider } from "react-dnd";
+import { HTML5Backend } from "react-dnd-html5-backend";
+import { useDnD } from "@/hooks/common/useDnD";
+
+interface DnDWrapperPropsType {
+  dragList: any[];
+  onDragging?: (newOrder: any[]) => void; // 항목이 드래그 중일 때 호출되는 함수
+  onDragEnd: (newOrder: any[]) => void; // 드래그가 종료되었을 때 호출되는 함수
+  children: (
+    item: any,
+    ref: React.RefObject<HTMLLIElement>,
+    isDragging: boolean,
+  ) => React.ReactNode; // 각 항목을 랜더링하는 함수
+  dragSectionName: string; // 드래그 섹션 이름(각  드래그리스트는 섹션 이름을 다르게 해야 각 섹션 아이템간 이동이 불가)
+}
+
+interface DraggableItemProps {
+  dragItem: any;
+  itemIndex: number; // 항목의 인덱스
+  onMove: (dragIndex: number, hoverIndex: number, isFinished: boolean) => void; // 항목이 이동했을 때 호출되는 함수
+  itemRenderer: (
+    dragItem: any,
+    ref: React.RefObject<HTMLLIElement>,
+    isDragging: boolean,
+  ) => React.ReactNode; // 항목을 랜더링하는 함수
+  dragSectionName: string; // 드래그 섹션 이름
+}
+
+// 드래그 앤 드랍을 처리하는 래퍼 컴포넌트를 정의한다.
+export const DnDWrapper = ({
+  dragList,
+  onDragging,
+  onDragEnd,
+  children,
+  dragSectionName,
+}: DnDWrapperPropsType) => {
+  const [currentItems, setCurrentItems] = useState(dragList); // 현재 항목의 상태 관리
+
+  // 항목이 이동했을 때 호출되는 함수.
+  const handleItemMove = (
+    dragIndex: number,
+    hoverIndex: number,
+    isFinished: boolean,
+  ) => {
+    const newItems = [...currentItems];
+    const [draggedItem] = newItems.splice(dragIndex, 1);
+    newItems.splice(hoverIndex, 0, draggedItem);
+    setCurrentItems(newItems);
+
+    if (isFinished) {
+      onDragEnd(newItems); // 드래그가 종료되었을 때 콜백 함수를 호출.
+    } else {
+      onDragging && onDragging(newItems); // 항목이 드래그 중일 때 콜백 함수를 호출.
+    }
+  };
+
+  // 각 항목을 랜더링.
+  return (
+    <DndProvider backend={HTML5Backend}>
+      {currentItems.map((item, idx) => (
+        <DraggableItem
+          key={item.id}
+          dragItem={item}
+          itemIndex={idx}
+          onMove={handleItemMove}
+          itemRenderer={children}
+          dragSectionName={dragSectionName}
+        />
+      ))}
+    </DndProvider>
+  );
+};
+
+// 드래그 가능한 항목 컴포넌트를 정의
+const DraggableItem = ({
+  dragItem,
+  itemIndex,
+  onMove,
+  itemRenderer,
+  dragSectionName,
+}: DraggableItemProps) => {
+  const { ref, isDragging } = useDnD({ itemIndex, onMove, dragSectionName }); // useDnD 훅을 사용하여 드래그 앤 드랍을 처리.
+  return itemRenderer(dragItem, ref, isDragging); // 항목 랜더링.
+};

--- a/src/example/DnDExample.tsx
+++ b/src/example/DnDExample.tsx
@@ -1,0 +1,128 @@
+/*
+  ** 드래그앤드랍 예제파일 **
+
+  * react-dnd-html5-backend 관련 에러뜰경우
+  패키지 인스톨필요 "yarn add react-dnd-html5-backend"
+
+  * 만약 DnDWrapper안에 컴포넌트를 칠드런으로 넘길경우 forwardRef사용 필수
+*/
+
+"use client";
+import React, { useState, ForwardedRef } from "react";
+import { DnDWrapper } from "@/components/DnDWrapper";
+
+export interface TestDnDItem {
+  id: string;
+  text: string;
+}
+
+const DnDExamplePage = () => {
+  const [initialItems, _] = useState<TestDnDItem[]>([
+    {
+      id: "1~",
+      text: "Write a cool JS library",
+    },
+    {
+      id: "2~",
+      text: "Make it generic enough",
+    },
+    {
+      id: "3~",
+      text: "Write README",
+    },
+    {
+      id: "4~",
+      text: "Create some examples",
+    },
+    {
+      id: "5~",
+      text: "Spam in Twitter and IRC to promote it",
+    },
+    {
+      id: "6~",
+      text: "???",
+    },
+    {
+      id: "7~",
+      text: "PROFIT",
+    },
+  ]);
+  const whenDragging = (newList: TestDnDItem[]) => {
+    // console.log("!드래그중일떄", newList);
+  };
+  const whenDragEnd = (newList: TestDnDItem[]) => {
+    console.log("@드래그끝났을떄", newList);
+  };
+
+  return (
+    <>
+      <div>DnD 예제코드.</div>
+      <div className="flex justify-around">
+        <div className="border border-gray-950 mb-10">
+          <DnDWrapper
+            dragList={initialItems}
+            onDragging={whenDragging}
+            onDragEnd={whenDragEnd}
+            dragSectionName={"abc"}
+          >
+            {(dragItem, ref, isDragging) => (
+              <li
+                ref={ref}
+                className={`p-2 border border-blue-700 m-2 ${
+                  isDragging ? "opacity-20" : ""
+                }`}
+              >
+                <p>{dragItem.id}</p>
+                <p>{dragItem.text}</p>
+              </li>
+            )}
+          </DnDWrapper>
+        </div>
+        <div className="border border-gray-950">
+          <DnDWrapper
+            dragList={initialItems}
+            onDragging={whenDragging}
+            onDragEnd={whenDragEnd}
+            dragSectionName={"def"}
+          >
+            {(dragItem, ref, isDragging) => (
+              <DnDTestComponent
+                dragData={dragItem}
+                ref={ref}
+                isDragging={isDragging}
+                zxzx="다른프롭스내려봄"
+                yzyz="또다른프롭스내려봄"
+              />
+            )}
+          </DnDWrapper>
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default DnDExamplePage;
+
+interface DnDTestComponentProps {
+  dragData: TestDnDItem;
+  isDragging: boolean;
+  zxzx: string;
+  yzyz: string;
+}
+
+const DnDTestComponent = React.forwardRef(
+  (
+    { dragData, isDragging, zxzx, yzyz }: DnDTestComponentProps,
+    // { dragData, isDragging, ...props }: DnDTestComponentProps,
+    ref: ForwardedRef<HTMLLIElement>,
+  ) => (
+    <li
+      ref={ref}
+      className={`p-2 border border-red m-2 ${isDragging ? "opacity-20" : ""}`}
+    >
+      <p>{dragData.id}</p>
+      <div>{yzyz}</div>
+      {/* <div>{props.zxzx}</div> */}
+    </li>
+  ),
+);

--- a/src/hooks/common/useDnD.tsx
+++ b/src/hooks/common/useDnD.tsx
@@ -1,0 +1,90 @@
+"use client";
+import { useRef } from "react";
+import { useDrag, useDrop } from "react-dnd";
+
+interface UseDnD {
+  itemIndex: number;
+  onMove: (dragIndex: number, hoverIndex: number, isFinished: boolean) => void;
+  dragSectionName: string;
+}
+interface DraggedItem {
+  type: string;
+  draggingItemCurrentIndex: number;
+}
+
+export const useDnD = ({ itemIndex, onMove, dragSectionName }: UseDnD) => {
+  // useRef를 사용해 HTMLLIElement에 대한 참조를 생성
+  const ref = useRef<HTMLLIElement>(null);
+
+  const [{ isDragging }, drag] = useDrag({
+    type: dragSectionName,
+    item: { type: dragSectionName, draggingItemCurrentIndex: itemIndex },
+    collect: monitor => ({ isDragging: monitor.isDragging() }),
+    end: (draggedItem: DraggedItem, monitor) => {
+      // 드래그 동작이 종료되었을 때의 동작 설정 (가장마지막동작,useDrop보다늦게동작)
+      const didDrop = monitor.didDrop();
+      if (!didDrop && ref.current) {
+        onMove(draggedItem.draggingItemCurrentIndex, itemIndex, true);
+      }
+    },
+  });
+
+  // 드롭 동작을 관리하기 위한 useDrop 훅 설정
+  const [, drop] = useDrop({
+    accept: dragSectionName,
+    hover: (draggingItem: DraggedItem, monitor) => {
+      // 현재 드래그 중인 항목이나 대상 항목이 유효하지 않을 경우 반환
+      if (!ref.current || draggingItem.draggingItemCurrentIndex === itemIndex)
+        return;
+
+      // 현재 항목의 위치와 크기 정보를 가져옴
+      const hoverBoundingRect = ref.current.getBoundingClientRect();
+
+      // 드래그 중인 항목의 현재 위치를 가져옴
+      const clientOffset = monitor.getClientOffset();
+      if (!clientOffset) return;
+
+      // 드래그 중인 항목의 위치와 크기 계산
+      const draggedItemRect = {
+        left: clientOffset.x,
+        right: clientOffset.x + hoverBoundingRect.width,
+        top: clientOffset.y,
+        bottom: clientOffset.y + hoverBoundingRect.height,
+      };
+
+      // 두 항목이 겹치는 영역을 계산
+      const overlapX = Math.max(
+        0,
+        Math.min(hoverBoundingRect.right, draggedItemRect.right) -
+          Math.max(hoverBoundingRect.left, draggedItemRect.left),
+      );
+      const overlapY = Math.max(
+        0,
+        Math.min(hoverBoundingRect.bottom, draggedItemRect.bottom) -
+          Math.max(hoverBoundingRect.top, draggedItemRect.top),
+      );
+
+      // 겹치는 영역의 면적 계산 후, 해당 면적이 전체 면적의 10%를 초과하면 위치 변경
+      const overlapArea = overlapX * overlapY;
+      const hoverArea = hoverBoundingRect.width * hoverBoundingRect.height;
+      const thresholdArea = hoverArea * 0.1;
+
+      if (overlapArea > thresholdArea) {
+        onMove(draggingItem.draggingItemCurrentIndex, itemIndex, false);
+        draggingItem.draggingItemCurrentIndex = itemIndex;
+      }
+    },
+    drop: (draggedItem: DraggedItem) => {
+      // 항목이 다른 항목 위에 드롭되었을 때 동작 설정
+      return onMove(draggedItem.draggingItemCurrentIndex, itemIndex, true);
+    },
+  });
+
+  // drag와 drop을 합쳐 해당 요소에 연결
+  drag(drop(ref));
+
+  return {
+    ref,
+    isDragging,
+  };
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -4952,7 +4952,6 @@ mdast-util-to-string@^3.0.0, mdast-util-to-string@^3.1.0:
   dependencies:
     "@types/mdast" "^3.0.0"
 
-
 merge-options@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/merge-options/-/merge-options-3.0.4.tgz#84709c2aa2a4b24c1981f66c179fe5565cc6dbb7"
@@ -5749,6 +5748,13 @@ queue-microtask@^1.2.2:
   resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243"
   integrity sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
 
+react-dnd-html5-backend@^16.0.1:
+  version "16.0.1"
+  resolved "https://registry.yarnpkg.com/react-dnd-html5-backend/-/react-dnd-html5-backend-16.0.1.tgz#87faef15845d512a23b3c08d29ecfd34871688b6"
+  integrity sha512-Wu3dw5aDJmOGw8WjH1I1/yTH+vlXEL4vmjk5p+MHxP8HuHJS1lAGeIdG/hze1AvNeXWo/JgULV87LyQOr+r5jw==
+  dependencies:
+    dnd-core "^16.0.1"
+
 react-dnd@^16.0.1:
   version "16.0.1"
   resolved "https://registry.yarnpkg.com/react-dnd/-/react-dnd-16.0.1.tgz#2442a3ec67892c60d40a1559eef45498ba26fa37"
@@ -5787,7 +5793,6 @@ react-is@^18.0.0:
   version "18.2.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.2.0.tgz#199431eeaaa2e09f86427efbb4f1473edb47609b"
   integrity sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==
-
 
 react-markdown@^8.0.7:
   version "8.0.7"


### PR DESCRIPTION
## 개요 :mag:

react-dnd 라이브러리를 이용해 사이드바 리스트 드래그앤드랍을 위한 공통컴포넌트제작,
사용예제코드 파일생성

## 작업사항 :memo:

 1. DnDWrapper.tsx생성
 2. 사용예제코드 (example/DnDExample.tsx)생성
 
## 테스트 방법(optional)

각아이템은 칠드런으로 넘기고 li태그를 사용해야하며 wrapper에서 넘겨주는 ref를 넣어줘야합니다.
드래그앤드랍 예시코드는 example/DnDExample.tsx에 작성해두었습니다 사용할때 참고해서 만드시면됩니다.
현재 지정해놓은 타입any는 추후 사용하는 타입만 넣을예정.

