### PR TITLE
Team4 feat 사이드바 섹션 dnd 및 섹션 타이틀 수정

### DIFF
--- a/src/app/classroom/(components)/ClassroomSidebar.tsx
+++ b/src/app/classroom/(components)/ClassroomSidebar.tsx
@@ -64,13 +64,16 @@ const ClassroomSidebar = ({
       if (result) {
         resultLectures.push(key);
       }
-      console.log(result);
     }
-    console.log("resultLectures : ", resultLectures);
+
     if (resultLectures.length > 0) {
       setCourseChecked([...resultLectures]);
+    } else if (resultLectures.length === 0) {
+      setCourseChecked([]);
     }
+    console.log("🤔 resultLectures:: ", resultLectures);
   };
+  console.log("🤔🤔 courseChecked:: ", courseChecked);
 
   // onCourseCheck 클릭 시, course의 체크 상태 값이 바뀜에 따라서 lecture들도 바뀐다.
   const onCourseCheck = (courseId: string) => {

--- a/src/app/classroom/(components)/ClassroomSidebar.tsx
+++ b/src/app/classroom/(components)/ClassroomSidebar.tsx
@@ -7,6 +7,8 @@ import { CourseProps } from "@/hooks/reactQuery/lecture/useGetCoursesInfoQuery";
 import Button from "@/app/classroom/(components)/Button";
 import useCreateCourse from "@/hooks/reactQuery/lecture/useCreateCourse";
 import useDeleteCourse from "@/hooks/reactQuery/lecture/useDeleteCourse";
+import useUpdateCourseTitle from "@/hooks/reactQuery/lecture/useUpdateCourseTitle";
+import { Course } from "@/types/firebase.types";
 
 interface ClassroomSidebarProps {
   courseData: CourseProps[];
@@ -21,13 +23,33 @@ const ClassroomSidebar = ({
 }: ClassroomSidebarProps) => {
   const [checkedLectureIds, setCheckedLectureIds] = useState<string[]>([]); // 체크된 강의 리스트
   const [courseChecked, setCourseChecked] = useState<string[]>([]); // 체크된 섹션
+  const [isEdit, setIsEdit] = useState<boolean>(false); // 섹션 수정 버튼 상태
+  const [isOpenCourse, setIsOpenCourse] = useState<boolean>(false); // 섹션 오픈 여부
 
-  // 섹션 수정 버튼 상태
-  const [isEdit, setIsEdit] = useState(false);
+  // 강의 타이틀을 변경하는 뮤테이션 훅
+  const { mutateAsync: updateCourseMutate } = useUpdateCourseTitle();
 
-  // 섹션 수정 버튼 토글
+  // 변경된 섹션 타이틀을 배열로 저장한다.
+  const [changeCourseTitle, setChangeCourseTitle] = useState<Course[]>([]);
+
+  // 섹션 수정 모드 핸들러
   const editButtonHandler = () => {
-    setIsEdit(!isEdit);
+    setIsEdit(!isEdit); // true (수정 가능 상태)
+    setIsOpenCourse(!isOpenCourse); // true (코스의 하위 강위 열기)
+  };
+
+  useEffect(() => {
+    if (isEdit) {
+      setIsOpenCourse(true);
+    }
+  }, [isEdit]);
+
+  // 섹션 수정 완료 핸들러(수정 모드를 나오기)
+  const editDoneButtonHandler = () => {
+    // 여기에서 나중에 현재 상황 적용하기 훅을 불러조야함.
+    setIsEdit(!isEdit); // true (수정 가능 상태)
+    setIsOpenCourse(!isOpenCourse); // true (코스의 하위 강위 열기)
+    updateCourseMutate(changeCourseTitle);
   };
 
   // 섹션 추가
@@ -71,9 +93,9 @@ const ClassroomSidebar = ({
     } else if (resultLectures.length === 0) {
       setCourseChecked([]);
     }
-    console.log("🤔 resultLectures:: ", resultLectures);
+    // console.log("📗 resultLectures:: ", resultLectures);
   };
-  console.log("🤔🤔 courseChecked:: ", courseChecked);
+  // console.log("📚 courseChecked:: ", courseChecked);
 
   // onCourseCheck 클릭 시, course의 체크 상태 값이 바뀜에 따라서 lecture들도 바뀐다.
   const onCourseCheck = (courseId: string) => {
@@ -115,15 +137,18 @@ const ClassroomSidebar = ({
           key={courseItem.id}
           courseData={courseItem}
           allLecturesData={allLecturesData[courseItem.id] || []}
-          isEdit={isEdit}
+          isEdit={isEdit} // 섹션 수정 상태
+          editButtonHandler={editButtonHandler} // 섹션 수정 상태 변경 핸들러
+          editDoneButtonHandler={editDoneButtonHandler} // 섹션 수정 완료 핸들러
+          isOpenCourse={isOpenCourse} // 강의 리스트 펼쳐짐 상태
           checkedLectureIds={checkedLectureIds}
           courseChecked={courseChecked}
-          editButtonHandler={editButtonHandler}
           setCheckedLectureIds={() => setCheckedLectureIds}
           setCourseChecked={setCourseChecked}
           onLectureCheck={(lectureId: string) => onLectureCheck(lectureId)}
           onCourseCheck={onCourseCheck}
           onClickedCourse={onClickedCourse}
+          setChangeCourseTitle={setChangeCourseTitle}
         />
       ))}
 
@@ -138,7 +163,7 @@ const ClassroomSidebar = ({
               <div className="flex justify-between mt-4">
                 <button
                   className="bg-primary-80 text-white h-[50px] px-[28px] py-[14px] rounded-[10px]"
-                  onClick={editButtonHandler}
+                  onClick={editDoneButtonHandler}
                 >
                   수정 완료
                 </button>

--- a/src/app/classroom/(components)/CourseSection.tsx
+++ b/src/app/classroom/(components)/CourseSection.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useRef } from "react";
 import Sidebar from "@/components/Sidebar";
 import useUpdateLectureOrder from "@/hooks/reactQuery/lecture/useUpdateLectureOrder";
 import { Lecture } from "@/types/firebase.types";
@@ -9,19 +9,23 @@ const CourseSection = ({
   courseData,
   allLecturesData,
   isEdit,
+  editDoneButtonHandler,
   checkedLectureIds,
   courseChecked,
   onLectureCheck,
   onCourseCheck,
   onClickedCourse,
+  isOpenCourse,
+  setChangeCourseTitle,
 }: any) => {
   const [isCheck, setIsChecked] = useState(false);
   const [lectureListItem, setLectureListItem] = useState([]);
 
   // 강의 순서를 변경하는 뮤테이션 훅
-  const { mutateAsync: updateMutate } = useUpdateLectureOrder();
+  const { mutateAsync: updateLectureOrderMutate } = useUpdateLectureOrder();
 
   useEffect(() => {
+    // 강의 순서를 변경
     const result = courseChecked.includes(courseData.id); // true, false
     const updateLectureList = allLecturesData.map((lecture: Lecture) => {
       return {
@@ -37,25 +41,87 @@ const CourseSection = ({
 
   const onDragEndTest = (movedLectureItem: any) => {
     setLectureListItem(movedLectureItem);
-    // 드래그 앤 드롭으로 변경된 순서를 Firebase에 저장한다.
-    updateMutate(movedLectureItem);
-    console.log("movedLectureItem!!: ", movedLectureItem);
+    updateLectureOrderMutate(movedLectureItem); // 드래그 앤 드롭으로 변경된 순서를 Firebase에 저장한다.
   };
 
-  console.log("lectureListItem::", lectureListItem);
+  // 더블 클릭으로 섹션 타이틀 수정하기
+  const editCourseTitle = (e: React.MouseEvent<HTMLButtonElement>) => {
+    // 섹션 타이틀에 해당하는 span 태그 id를 탐색해서, input 창으로 바꾸고 원하는 텍스트로 바꾸는 함수
+    // sectionTitleElement는 courseData.id에 해당하는 태그를 들고온다. ( 섹션 타이틀의 감싸는 태그에 coureData.id 에 해당하는 id 값을 지정햤다. )
+    const sectionTitleElement = document.getElementById(courseData.id);
+    if (isEdit) {
+      if (sectionTitleElement) {
+        // 해당 sectionTitleElement 태그가 존재하면 아래의 내용을 실행한다.
+        const currentValue = sectionTitleElement.textContent || ""; // sectionTitleElement의 현재 텍스트 값(섹션 타이틀)을 저장한다.
+        const editDiv = document.createElement("div");
+        const inputElement = document.createElement("input");
+
+        inputElement.type = "text";
+        inputElement.value = currentValue;
+        inputElement.className = "w-36";
+        editDiv.appendChild(inputElement);
+
+        // 클릭 이벤트가 상위 요소로 전파되지 않게 함
+        inputElement.addEventListener("click", e => e.stopPropagation());
+
+        // 저장 버튼 생성
+        const saveButton = document.createElement("button");
+        saveButton.textContent = "저장";
+        editDiv.appendChild(saveButton); // editDiv 안에 저장 button을 자식요소로 두어서
+        saveButton.style.display = "none";
+
+        // 엔터 클릭 시, 키보드 이벤트 발동하며
+        inputElement.addEventListener("keydown", e => {
+          if (e.key === "Enter") {
+            const newValue = inputElement.value; // 새로 입력된 값을 newValue에 할당 한다.
+            sectionTitleElement.textContent = newValue; // 저장 버튼 클릭 시, 새로 입력한 값을 span의 텍스트로 바꿈
+            editDiv.replaceWith(sectionTitleElement); // 해당 이벤트 실행 시, editDiv(편집모드) 태그를 sectionTitleElement로 변환
+            setChangeCourseTitle((prevTitles: any) => {
+              // 기존에 동일한 id가 있는지 찾기
+              const existingCourseIndex = prevTitles.findIndex(
+                (course: any) => course.id === courseData.id,
+              );
+
+              // 동일한 id가 있다면, 해당 항목의 title만 변경
+              if (existingCourseIndex > -1) {
+                const newTitles = [...prevTitles];
+                newTitles[existingCourseIndex].title = newValue;
+                return newTitles;
+              }
+
+              // 동일한 id가 없다면, 새로운 객체를 배열에 추가
+              return [...prevTitles, { id: courseData.id, title: newValue }];
+            });
+          }
+        });
+
+        // 더블 클릭하는 애가 span(sectionTitleElement)이고, 더블 클릭 시, editDiv(input과 button 있는 곳)로 바꿈
+        sectionTitleElement.replaceWith(editDiv); // 이 코드가 실행되면, sectionTitleElement 를 editDiv 로 변환
+        inputElement.focus();
+      }
+      console.log("span에 적용된 변경된 섹션 타이틀: ", sectionTitleElement);
+    }
+  };
 
   return (
-    <button onClick={() => onClickedCourse(courseData.id)} className="mb-2">
+    <button
+      onClick={() => onClickedCourse(courseData.id)}
+      onDoubleClick={editCourseTitle}
+      className="mb-2"
+    >
       <Sidebar
         key={courseData.id}
         courseId={courseData.id}
         header={courseData.title}
-        contents={lectureListItem}
-        isEdit={isEdit}
+        contents={lectureListItem} // 강의 리스트들
+        isEdit={isEdit} // 섹션 수정 상태
+        editDoneButtonHandler={editDoneButtonHandler}
+        isOpenCourse={isOpenCourse} // 강의 리스트 펼쳐짐 상태
         lectureCheckHandler={onLectureCheck} // 각 강의 항목 체크 여부
         isCourseChecked={isCheck} // 강의 중 하나라도 체크가 해제될 시, 섹션도 체크 해제 됨(코스의 체크 여부)
         courseCheckHandler={onCourseCheck} // 코스 섹션 체크 토글
         onDragEnd={onDragEndTest}
+        setChangeCourseTitle={setChangeCourseTitle}
       />
     </button>
   );

--- a/src/app/classroom/(components)/CourseSection.tsx
+++ b/src/app/classroom/(components)/CourseSection.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState, useEffect } from "react";
 import Sidebar from "@/components/Sidebar";
+import useUpdateLectureOrder from "@/hooks/reactQuery/lecture/useUpdateLectureOrder";
 import { Lecture } from "@/types/firebase.types";
 
 const CourseSection = ({
@@ -15,11 +16,33 @@ const CourseSection = ({
   onClickedCourse,
 }: any) => {
   const [isCheck, setIsChecked] = useState(false);
+  const [lectureListItem, setLectureListItem] = useState([]);
+
+  // 강의 순서를 변경하는 뮤테이션 훅
+  const { mutateAsync: updateMutate } = useUpdateLectureOrder();
+
   useEffect(() => {
-    const result = courseChecked.includes(courseData.id);
-    console.log("체크 결과", result);
+    const result = courseChecked.includes(courseData.id); // true, false
+    const updateLectureList = allLecturesData.map((lecture: Lecture) => {
+      return {
+        id: lecture.id,
+        title: lecture.title,
+        checked: checkedLectureIds.includes(lecture.id),
+      };
+    });
+
     setIsChecked(result);
-  }, [courseChecked, courseData]);
+    setLectureListItem(updateLectureList);
+  }, [courseChecked, courseData, allLecturesData, checkedLectureIds]);
+
+  const onDragEndTest = (movedLectureItem: any) => {
+    setLectureListItem(movedLectureItem);
+    // 드래그 앤 드롭으로 변경된 순서를 Firebase에 저장한다.
+    updateMutate(movedLectureItem);
+    console.log("movedLectureItem!!: ", movedLectureItem);
+  };
+
+  console.log("lectureListItem::", lectureListItem);
 
   return (
     <button onClick={() => onClickedCourse(courseData.id)} className="mb-2">
@@ -27,19 +50,12 @@ const CourseSection = ({
         key={courseData.id}
         courseId={courseData.id}
         header={courseData.title}
-        contents={
-          allLecturesData.map((lecture: Lecture) => {
-            return {
-              id: lecture.id,
-              title: lecture.title,
-              checked: checkedLectureIds.includes(lecture.id),
-            };
-          }) || []
-        }
+        contents={lectureListItem}
         isEdit={isEdit}
         lectureCheckHandler={onLectureCheck} // 각 강의 항목 체크 여부
         isCourseChecked={isCheck} // 강의 중 하나라도 체크가 해제될 시, 섹션도 체크 해제 됨(코스의 체크 여부)
         courseCheckHandler={onCourseCheck} // 코스 섹션 체크 토글
+        onDragEnd={onDragEndTest}
       />
     </button>
   );

--- a/src/app/classroom/(components)/LectureItem.tsx
+++ b/src/app/classroom/(components)/LectureItem.tsx
@@ -53,17 +53,17 @@ const LectureItem = ({ item, index }: { item: Lecture; index: number }) => {
         <h3 className="text-base font-bold">
           {`${lectureIcon} ` + `${title}`}
         </h3>
-        <p className="text-xs font-medium">
+        <div className="text-xs font-medium">
           [수강기간]
-          <div>
+          <p>
             {startDate.seconds}~{endDate.seconds}
-          </div>
-        </p>
+          </p>
+        </div>
       </div>
       <div className="flex flex-col justify-between">
         <div className="text-sm text-right">
-          <button>수정</button>
-          <button>삭제</button>
+          <button className="b mr-1">수정</button>
+          <button onClick={() => {}}>삭제</button>
         </div>
         <button
           className="bg-grayscale-5 px-14 py-2 rounded-lg"

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -2,6 +2,7 @@
 
 import { Lecture } from "@/types/firebase.types";
 import React, { useState } from "react";
+import { DnDWrapper } from "./DnDWrapper";
 
 export interface Content {
   id: Lecture["id"];
@@ -18,6 +19,10 @@ interface Props {
   isCourseChecked?: boolean;
   lectureCheckHandler?: (id: string) => void;
   courseCheckHandler?: (courseId: string) => void;
+  onDragEnd: (newOrder: any[]) => void;
+  isOpenCourse: boolean;
+  editDoneButtonHandler: () => void;
+  setChangeCourseTitle: string[];
 }
 
 const Sidebar = ({
@@ -28,56 +33,111 @@ const Sidebar = ({
   isCourseChecked,
   lectureCheckHandler,
   courseCheckHandler,
+  onDragEnd,
+  isOpenCourse,
 }: Props) => {
-  const [isOpen, setIsOpen] = useState(false);
+  const [isOpen, setIsOpen] = useState(false); // 강의 리스트 닫힌 상태
+
+  const onOpenCourse = () => {
+    if (!isEdit) {
+      // 수정 상태가 true면,
+      setIsOpen(!isOpen); // 오픈해두고(true)
+    } else {
+      setIsOpen(isOpen); // 닫고(false)
+    }
+  };
+
   return (
     <div className="w-[245px]">
       <div
         className="flex items-center py-[13px] rounded-[10px] text-grayscale-80 bg-primary-5 cursor-pointer"
-        onClick={() => setIsOpen(!isOpen)}
+        onClick={onOpenCourse}
       >
+        {/* 섹션의 체크박스 영역 */}
         <div className="w-[55px] flex justify-center items-center">
           {isEdit ? (
-            <input
-              type="checkbox"
-              onClick={(e: React.MouseEvent) => e.stopPropagation()}
-              onChange={() => {
-                if (courseCheckHandler !== undefined)
-                  courseCheckHandler(courseId as string);
-              }}
-              value={courseId}
-              checked={isCourseChecked}
-            />
+            <>
+              <input
+                type="checkbox"
+                onClick={(e: React.MouseEvent) => e.stopPropagation()}
+                onChange={() => {
+                  if (courseCheckHandler !== undefined)
+                    courseCheckHandler(courseId as string);
+                }}
+                value={courseId}
+                checked={isCourseChecked}
+              />
+            </>
           ) : (
             <span className="text-sm">🎯</span>
           )}
         </div>
-        {header}
+        {/* 섹션의 타이틀 영역 */}
+        <span id={courseId}>{header}</span>
       </div>
-      {isOpen && (
+
+      {/* 섹션의 하위 강의 리스트 영역 --> 위에서 섹션 타이틀 클릭여부에 따라 isOpen 상태가 결정된다. */}
+      {isOpen || isOpenCourse ? (
         <ul className="my-[10px]">
-          {contents.map(content => (
-            <li
-              key={content.id}
-              className="flex items-center text-sm text-grayscale-80 py-[10px] cursor-pointer"
+          {!isEdit ? (
+            <>
+              {contents.map(content => (
+                <li
+                  key={content.id}
+                  className="flex items-center text-sm text-grayscale-80 py-[10px] cursor-pointer"
+                >
+                  <div className="w-[55px] flex justify-center items-center">
+                    {isEdit && (
+                      <input
+                        type="checkbox"
+                        value={content.id}
+                        onChange={() => {
+                          if (lectureCheckHandler !== undefined)
+                            lectureCheckHandler(content.id);
+                        }}
+                        checked={content.checked}
+                      />
+                    )}
+                  </div>
+                  {content.title}
+                </li>
+              ))}
+            </>
+          ) : (
+            <DnDWrapper
+              dragSectionName={courseId ? courseId : "dragSectionName"}
+              dragList={contents}
+              onDragEnd={onDragEnd}
             >
-              <div className="w-[55px] flex justify-center items-center">
-                {isEdit && (
-                  <input
-                    type="checkbox"
-                    value={content.id}
-                    onChange={() => {
-                      if (lectureCheckHandler !== undefined)
-                        lectureCheckHandler(content.id);
-                    }}
-                    checked={content.checked}
-                  />
-                )}
-              </div>
-              {content.title}
-            </li>
-          ))}
+              {(dragItem, ref, isDragging) => (
+                <li
+                  ref={ref}
+                  key={dragItem.id}
+                  className={`flex items-center text-sm text-grayscale-80 py-[10px] cursor-pointer ${
+                    isDragging && "opacity-20"
+                  }`}
+                >
+                  <div className="w-[55px] flex justify-center items-center">
+                    {isEdit && (
+                      <input
+                        type="checkbox"
+                        value={dragItem.id}
+                        onChange={() => {
+                          if (lectureCheckHandler !== undefined)
+                            lectureCheckHandler(dragItem.id);
+                        }}
+                        checked={dragItem.checked}
+                      />
+                    )}
+                  </div>
+                  {dragItem.title}
+                </li>
+              )}
+            </DnDWrapper>
+          )}
         </ul>
+      ) : (
+        <></>
       )}
     </div>
   );

--- a/src/hooks/reactQuery/lecture/useUpdateCourseTitle.ts
+++ b/src/hooks/reactQuery/lecture/useUpdateCourseTitle.ts
@@ -1,0 +1,29 @@
+import { db } from "@/utils/firebase";
+import { doc, writeBatch } from "firebase/firestore";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { Course } from "@/types/firebase.types";
+
+const updateCourseTitle = async (updateTitle: Course[]) => {
+  const batch = writeBatch(db);
+
+  updateTitle.forEach(course => {
+    const courseRef = doc(db, "courses", course.id);
+    batch.update(courseRef, { title: course.title });
+  });
+  console.log("updateTitle: ", updateTitle);
+  await batch.commit();
+};
+
+const useUpdateCourseTitle = () => {
+  const queryClient = useQueryClient();
+  return useMutation(updateCourseTitle, {
+    onSuccess: () => {
+      queryClient.invalidateQueries(["courses"]);
+    },
+    onError: (e: unknown) => {
+      console.log("에러가 발생하였습니다.", e);
+    },
+  });
+};
+
+export default useUpdateCourseTitle;

--- a/src/hooks/reactQuery/lecture/useUpdateLectureOrder.ts
+++ b/src/hooks/reactQuery/lecture/useUpdateLectureOrder.ts
@@ -1,0 +1,30 @@
+import { db } from "@/utils/firebase";
+import { writeBatch, doc } from "firebase/firestore";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { Lecture } from "@/types/firebase.types";
+
+const updateLectureOrder = async (updatedList: Lecture[]) => {
+  const batch = writeBatch(db);
+
+  updatedList.forEach(lecture => {
+    const lectureRef = doc(db, "lectures", lecture.id);
+    batch.update(lectureRef, { order: lecture.order });
+  });
+
+  await batch.commit();
+};
+
+// updateLectureOrder 여기에 반영된 내용을 바탕으로 리액트 쿼리가 해당 lecture라는 키값을 가진 컬렉션을 업데이트 해준다.
+export const useUpdateLectureOrder = () => {
+  const queryClient = useQueryClient();
+  return useMutation(updateLectureOrder, {
+    onSuccess: () => {
+      queryClient.invalidateQueries(["lecture"]);
+    },
+    onError: (e: unknown) => {
+      console.log("에러가 발생하였습니다.", e);
+    },
+  });
+};
+
+export default useUpdateLectureOrder;


### PR DESCRIPTION
## 개요 :mag:
- 강의 리스트의 DnD 기능 적용
- 클래스룸 사이드바의 섹션 타이틀 수정 기능 추가

## 작업사항 :memo:
- 강의리스트 DnD 기능 실시간으로 적용되게 만들기
- 강의리스트 DnD 훅 생성
- 섹션 타이틀 수정
- 섹션 타이틀 수정 훅 생성

#127 Feat: 강의리스트 실시간으로 DnD 적용하기
#133 Feat: 사이드바 섹션 타이틀 수정 기능

## 테스트 방법(optional)
- 강의리스트 DnD 기능 사용 방법
  - [섹션 수정] 버튼 클릭 후, 강의 리스트를 드래그앤드롭 하면 됩니다.

- 섹션 타이틀 수정 방법
  - [섹션 수정] 버튼 클릭 후, 수정하고자 하는 섹션을 더블 클릭 하여 원하는 텍스트를 입력합니다.
  - Enter 버튼을 누르고, [수정 완료] 버튼 클릭 시, 섹션 타이틀 변경 사항이 적용됩니다.