### PR TITLE
Team8 과제삭제관련로직 추가 & layout생성 푸터와 margin

### DIFF
--- a/src/app/assignment/(components)/AssignmentSidebar.tsx
+++ b/src/app/assignment/(components)/AssignmentSidebar.tsx
@@ -55,11 +55,11 @@ const AssignmentSidebar = ({ list, userId, role }: AssignmentSidebarProps) => {
     setAssignmentList(newList);
     setIsOrderChanged(true);
   };
-  // useEffect(() => {
-  //   if (!isOrderChanged) {
-  //     setAssignmentList(list);
-  //   }
-  // }, [list]);
+  useEffect(() => {
+    if (!isOrderChanged) {
+      setAssignmentList(list);
+    }
+  }, [list]);
   return (
     <aside>
       <div className="relative">

--- a/src/app/assignment/[assignmentId]/(assignmentDetail)/Main.tsx
+++ b/src/app/assignment/[assignmentId]/(assignmentDetail)/Main.tsx
@@ -9,8 +9,8 @@ import { useAppSelector } from "@/redux/store";
 import { db } from "@/utils/firebase";
 import timestampToDate from "@/utils/timestampToDate";
 import { deleteDoc, doc } from "firebase/firestore";
-import { useParams } from "next/navigation";
-import router from "next/router";
+import { useParams, useRouter } from "next/navigation";
+// import router from "next/router";
 import React, { useState } from "react";
 import Modal from "../../(components)/(assignmentCreateModal)/Modal";
 import { Read } from "./Detail";
@@ -23,9 +23,13 @@ import {
 } from "@/hooks/reactQuery/submittedAssignment/useGetSubmittedAssignment";
 import { Assignment } from "@/types/firebase.types";
 import { Card } from "sfac-designkit-react";
+import { useDeleteAssignments } from "@/hooks/reactQuery/assignment/useDeleteAssignments";
 
 const Main = ({ read }: { read: Read }) => {
   const { assignmentId } = useParams();
+  const router = useRouter();
+  const { mutateAsync: deleteMutate, isLoading: deleteIsLoading } =
+    useDeleteAssignments();
 
   const userId = useAppSelector(state => state.userInfo.id);
   const { data: userData } = fetchUserInfo(userId);
@@ -66,6 +70,16 @@ const Main = ({ read }: { read: Read }) => {
       <p key={index}>{text}</p>
     ));
   };
+
+  const deleteAssignment = async () => {
+    const beforeCheck = confirm("선택된 과제를 삭제하시겠습니까??");
+    if (beforeCheck) {
+      const deleteIdInArr: string[] = [String(assignmentId)];
+      await deleteMutate(deleteIdInArr);
+      router.push("/assignment");
+    }
+  };
+
   if (isLoading) return <div>로딩중...</div>;
   return (
     <>
@@ -124,10 +138,7 @@ const Main = ({ read }: { read: Read }) => {
             <div className="w-[1px] h-[14px] bg-grayscale-30"></div>
             <span
               className="text-grayscale-100 text-[12px] font-[400] leading-[14.4px] cursor-pointer"
-              onClick={async () => {
-                await deleteDoc(doc(db, "assignments", assignmentId as string));
-                router.push("/assignment");
-              }}
+              onClick={deleteAssignment}
             >
               삭제
             </span>

--- a/src/app/assignment/layout.tsx
+++ b/src/app/assignment/layout.tsx
@@ -1,0 +1,11 @@
+import React from "react";
+
+interface AssignmentLayoutProps {
+  children: React.ReactNode;
+}
+
+const AssignmentLayout = ({ children }: AssignmentLayoutProps) => {
+  return <div className="mb-[172px]">{children}</div>;
+};
+
+export default AssignmentLayout;

--- a/src/hooks/reactQuery/assignment/useDeleteAssignments.tsx
+++ b/src/hooks/reactQuery/assignment/useDeleteAssignments.tsx
@@ -1,12 +1,49 @@
 import { db } from "@/utils/firebase";
-import { doc, writeBatch } from "firebase/firestore";
+import { collection, doc, getDocs, writeBatch } from "firebase/firestore";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 
 const deleteAssignments = async (deleteList: string[]) => {
+  // console.log(deleteList);
   const batch = writeBatch(db);
 
   deleteList.forEach(deleteItem => {
     const documentRef = doc(db, "assignments", deleteItem);
+    batch.delete(documentRef);
+  });
+
+  // assignment삭제시 그삭제된 id참조해서 submittedAssignment도 삭제
+  const submittedAssignmentsRef = collection(db, "submittedAssignments");
+  const submittedAssignmentsSnapshot = await getDocs(submittedAssignmentsRef);
+
+  const submitAssignmentsDeleteList: string[] = [];
+
+  submittedAssignmentsSnapshot.forEach(doc => {
+    const data = doc.data();
+    if (deleteList.includes(data.assignmentId.id))
+      submitAssignmentsDeleteList.push(doc.id);
+  });
+
+  submitAssignmentsDeleteList.forEach(deleteItem => {
+    const documentRef = doc(db, "submittedAssignments", deleteItem);
+    batch.delete(documentRef);
+  });
+  // console.log(submitAssignmentsDeleteList);
+
+  // submittedAssignment삭제시 그삭제된 id참조해서 attachment도 삭제
+  const attachmentsRef = collection(db, "attachments");
+  const attachmentsSnapshot = await getDocs(attachmentsRef);
+
+  const attachmentsDeleteList: string[] = [];
+
+  attachmentsSnapshot.forEach(doc => {
+    const data = doc.data();
+    if (submitAssignmentsDeleteList.includes(data.submittedAssignmentId.id))
+      attachmentsDeleteList.push(doc.id);
+  });
+  // console.log(attachmentsDeleteList);
+
+  attachmentsDeleteList.forEach(deleteItem => {
+    const documentRef = doc(db, "attachments", deleteItem);
     batch.delete(documentRef);
   });
 
@@ -25,3 +62,44 @@ export const useDeleteAssignments = () => {
     // },
   });
 };
+
+// const deleteSubmittedAssginments = async (deleteAssignmentsList: string[]) => {
+//   const batch = writeBatch(db);
+//   const submittedAssignmentsRef = collection(db, "submittedAssignments");
+//   const submittedAssignmentsSnapshot = await getDocs(submittedAssignmentsRef);
+
+//   const submitAssignmentsDeleteList: string[] = [];
+
+//   submittedAssignmentsSnapshot.forEach(doc => {
+//     const data = doc.data();
+//     if (deleteAssignmentsList.includes(data.assignmentId.id))
+//       submitAssignmentsDeleteList.push(doc.id);
+//   });
+
+//   submitAssignmentsDeleteList.forEach(deleteItem => {
+//     const documentRef = doc(db, "submittedAssignments", deleteItem);
+//     batch.delete(documentRef);
+//   });
+
+//   await batch.commit();
+// };
+// const deleteAttachments = async (deleteAttachmentsList: string[]) => {
+//   const batch = writeBatch(db);
+//   const attachmentsRef = collection(db, "attachments");
+//   const attachmentsSnapshot = await getDocs(attachmentsRef);
+
+//   const attachmentsDeleteList: string[] = [];
+
+//   attachmentsSnapshot.forEach(doc => {
+//     const data = doc.data();
+//     if (deleteAttachmentsList.includes(data.submittedAssignmentId.id))
+//       attachmentsDeleteList.push(doc.id);
+//   });
+
+//   attachmentsDeleteList.forEach(deleteItem => {
+//     const documentRef = doc(db, "attachments", deleteItem);
+//     batch.delete(documentRef);
+//   });
+
+//   await batch.commit();
+// };


### PR DESCRIPTION
## 개요 :mag:

과제 삭제시 서밋티드어사인먼트와 어태치먼트 콜렉션도 관련 문서 삭제해야해서 로직추가함
과제 디테일페이지에서 삭제시 삭제훅적용

## 작업사항 :memo:

 1. 과제삭제 로직 기능 추가 (submittedAssignments & attachment)
 2. 디테일페이지 삭제시 useDeleteAssignment훅적용

