### PR TITLE
Fix: LectureVideo 에러 수정

### DIFF
--- a/src/app/classroom/(components)/LectureVideo.tsx
+++ b/src/app/classroom/(components)/LectureVideo.tsx
@@ -38,7 +38,7 @@ export default function LectureVideo({
   const videoRef = useRef<HTMLVideoElement | null>(null);
 
   useEffect(() => {
-    if (files[0].size !== 0 && videoRef.current) {
+    if (files.length !== 0 && videoRef.current) {
       videoRef.current.src = URL.createObjectURL(files[0]);
       videoRef.current.onloadedmetadata = () => {
         setDuration(secondsToTime(videoRef.current!.duration));


### PR DESCRIPTION
## 개요 :mag:

videoLength 기본값 설정 중 수정했던 코드로 인해 발생하는 에러를 수정하였습니다.

## 작업사항 :memo:

```JS
// src/app/classroom/(components)/LectureVideo.tsx 40번째 줄
useEffect(() => {
  if (files[0].size!== 0 && videoRef.current) {
    videoRef.current.src = URL.createObjectURL(files[0]);
  ...
}
```

위 조건문에서 files[0]이 undefined일 경우 size를 찾지 못하는 에러가 발생하였습니다.

```JS
// src/app/classroom/(components)/LectureVideo.tsx 40번째 줄
useEffect(() => {
  if (files.length !== 0 && videoRef.current) {
    videoRef.current.src = URL.createObjectURL(files[0]);
  ...
}
```
따라서 원래 사용하던 위 유효성 검사 코드로 롤백하였습니다.